### PR TITLE
Fix unicode error in python 2

### DIFF
--- a/open_seq2seq/models/text2text.py
+++ b/open_seq2seq/models/text2text.py
@@ -97,10 +97,6 @@ class BasicText2TextWithAttention(Seq2Seq):
         )
         fout.write(output_string + "\n")
         if step % 200 == 0:
-          if six.PY2:
-            input_string = input_string.encode('utf-8')
-            output_string = output_string.encode('utf-8')
-
           deco_print("Input sequence:  {}".format(input_string))
           deco_print("Output sequence: {}".format(output_string))
           deco_print("")


### PR DESCRIPTION
There is a bug running inference in text2text. My guess that after we added from __future__ import unicode_literats, the if six.PY2 part is not needed anymore and breaks something.