### PR TITLE
Fix epoch number for horovod

### DIFF
--- a/open_seq2seq/models/model.py
+++ b/open_seq2seq/models/model.py
@@ -253,7 +253,7 @@ class Model:
         # if on Horovod, there will be hvd.size() independent data_layer copies
         # and thus the total size is hvd.size() times smaller.
         if self.on_horovod:
-          self._steps_in_epoch /= self._hvd.size()
+          self._steps_in_epoch //= self._hvd.size()
         self._last_step = self._params['num_epochs'] * self._steps_in_epoch
 
     self._outputs = [None] * self.num_gpus


### PR DESCRIPTION
There was a bug with float division (should have been integer) that affected only horovod execution.