### PR TITLE
Make iter_size work with IndexedSlices

### DIFF
--- a/open_seq2seq/optimizers/optimizers.py
+++ b/open_seq2seq/optimizers/optimizers.py
@@ -192,7 +192,7 @@ def optimize_loss(loss,
             initial_value=tf.zeros_like(var),
             name=grad.name.split(":")[0] + "_accum",
             expected_shape=var.shape,
-            dtype=grad.dtype,
+            dtype=var.dtype,
             trainable=False,
             validate_shape=bool(var.get_shape())
           )


### PR DESCRIPTION
In this approach we will have sparse gradients stored in dense variable and then added in a dense way to embedding. Might be more efficient to convert them to sparse variable before adding, but that needs some additional testing.