### PR TITLE
Adds loss scale summary to tensorboard and exposes loss scaling params to config files

### DIFF
--- a/example_configs/text2speech/LJ_example_config_mixed.py
+++ b/example_configs/text2speech/LJ_example_config_mixed.py
@@ -71,7 +71,8 @@ base_params = {
   "initializer": tf.contrib.layers.xavier_initializer,
 
   "summaries": ['learning_rate', 'variables', 'gradients', 'larc_summaries',
-                'variable_norm', 'gradient_norm', 'global_gradient_norm'],
+                'variable_norm', 'gradient_norm', 'global_gradient_norm',
+                'loss_scale'],
 
   "encoder": Tacotron2Encoder,
   "encoder_params": {

--- a/open_seq2seq/models/model.py
+++ b/open_seq2seq/models/model.py
@@ -178,7 +178,7 @@ class Model:
       parameters.
     * **summaries** (list) --- which summaries to log. Could contain
       "learning_rate", "gradients", "gradient_norm", "global_gradient_norm",
-      "variables", "variable_norm".
+      "variables", "variable_norm", "loss_scale".
     * **iter_size** (int) --- use this parameter to emulate large batches.
       The gradients will be accumulated for ``iter_size`` number of steps before
       applying update.

--- a/open_seq2seq/models/model.py
+++ b/open_seq2seq/models/model.py
@@ -83,6 +83,7 @@ class Model:
         'max_grad_norm': float,
         'larc_params': dict,
         'loss_scaling': None,  # float, "Backoff" or "LogMax"
+        'loss_scaling_params': dict,
         'summaries': list,
         'iter_size': int,
     }
@@ -173,6 +174,8 @@ class Model:
       loss scaling algorithm is used. Must be one of 'Backoff'
       of 'LogMax' (case insensitive). Only used when dtype="mixed". For details
       see :ref:`mixed precision training <mixed_precision>` section in docs.
+    * **loss_scaling_params** (dict) --- dictionary containing loss scaling
+      parameters.
     * **summaries** (list) --- which summaries to log. Could contain
       "learning_rate", "gradients", "gradient_norm", "global_gradient_norm",
       "variables", "variable_norm".
@@ -400,6 +403,7 @@ class Model:
           summaries=self.params.get('summaries', None),
           larc_params=self.params.get('larc_params', None),
           loss_scaling=self.params.get('loss_scaling', 1.0),
+          loss_scaling_params=self.params.get('loss_scaling_params', None),
           on_horovod=self.on_horovod,
           iter_size=self.params.get('iter_size', 1),
           skip_update_ph=self.skip_update_ph,

--- a/open_seq2seq/optimizers/automatic_loss_scaler.py
+++ b/open_seq2seq/optimizers/automatic_loss_scaler.py
@@ -62,7 +62,7 @@ class BackoffScaler(object):
         },
     )
     self.scale_min = params.get('scale_min', 1.0)
-    self.scale_max = params.get('scale_max', 2**.24)
+    self.scale_max = params.get('scale_max', 2.**24)
     self.step_factor = params.get('step_factor', 2.0)
     self.step_window = params.get('step_window', 2000)
 

--- a/open_seq2seq/optimizers/automatic_loss_scaler.py
+++ b/open_seq2seq/optimizers/automatic_loss_scaler.py
@@ -72,7 +72,7 @@ class BackoffScaler(object):
     self.last_overflow_iteration = tf.Variable(initial_value=-1,
                                                trainable=False,
                                                dtype=tf.int64)
-    self.scale = tf.Variable(initial_value=2.**24,
+    self.scale = tf.Variable(initial_value=self.scale_max,
                              trainable=False)
 
   def update_op(self, has_nan, amax):

--- a/open_seq2seq/optimizers/automatic_loss_scaler.py
+++ b/open_seq2seq/optimizers/automatic_loss_scaler.py
@@ -6,24 +6,17 @@ from __future__ import unicode_literals
 
 import tensorflow as tf
 
+from open_seq2seq.utils.utils import check_params
 
 class AutomaticLossScaler(object):
   SUPPORTED_ALGOS = ['backoff', 'logmax']
 
-  def __init__(self, algorithm='Backoff', scale_min=1.0, scale_max=2.**24):
+  def __init__(self, algorithm='Backoff', params=None):
     algorithm = algorithm.lower().strip()
     if algorithm == 'backoff':
-      self.scaler = BackoffScaler(scale_min=scale_min,
-                                  scale_max=scale_max,
-                                  step_factor=2.0,
-                                  step_window=2000)
+      self.scaler = BackoffScaler(params)
     elif algorithm == 'logmax':
-      self.scaler = LogMaxScaler(scale_min=scale_min,
-                                 scale_max=scale_max,
-                                 log_max=16.,
-                                 beta1=0.99,
-                                 beta2=0.999,
-                                 overflow_std_dev=3.09)  # ppf(.999)
+      self.scaler = LogMaxScaler(params)  # ppf(.999)
     else:
       raise ValueError('Unknown scaling algorithm: {}'.format(algorithm))
 
@@ -55,11 +48,23 @@ class AutomaticLossScaler(object):
 
 
 class BackoffScaler(object):
-  def __init__(self, scale_min, scale_max, step_factor, step_window):
-    self.scale_min = scale_min
-    self.scale_max = scale_max
-    self.step_factor = step_factor
-    self.step_window = step_window
+  def __init__(self, params):
+    if params is None:
+      params = {}
+    check_params(
+        config=params,
+        required_dict={},
+        optional_dict={
+            'scale_min': float,
+            'scale_max': float,
+            'step_factor': float,
+            'step_window': int
+        },
+    )
+    self.scale_min = params.get('scale_min', 1.0)
+    self.scale_max = params.get('scale_max', 2**.24)
+    self.step_factor = params.get('step_factor', 2.0)
+    self.step_window = params.get('step_window', 2000)
 
     self.iteration = tf.Variable(initial_value=0,
                                  trainable=False,
@@ -106,14 +111,27 @@ class BackoffScaler(object):
 
 
 class LogMaxScaler(object):
-  def __init__(self, scale_min, scale_max, log_max,
-               beta1, beta2, overflow_std_dev):
-    self.scale_min = scale_min
-    self.scale_max = scale_max
-    self.log_max = log_max
-    self.beta1 = beta1
-    self.beta2 = beta2
-    self.overflow_std_dev = overflow_std_dev
+  def __init__(self, params):
+    if params is None:
+      params = {}
+    check_params(
+        config=params,
+        required_dict={},
+        optional_dict={
+            'scale_min': float,
+            'scale_max': float,
+            'log_max': float,
+            'beta1': float,
+            'beta2': float,
+            'overflow_std_dev': float
+        },
+    )
+    self.scale_min = params.get('scale_min', 1.0)
+    self.scale_max = params.get('scale_max', 2.**24)
+    self.log_max = params.get('log_max', 16.)
+    self.beta1 = params.get('beta1', 0.99)
+    self.beta2 = params.get('beta2', 0.999)
+    self.overflow_std_dev = params.get('overflow_std_dev', 3.09)
 
     self.iteration = tf.Variable(initial_value=0,
                                  trainable=False,

--- a/open_seq2seq/optimizers/optimizers.py
+++ b/open_seq2seq/optimizers/optimizers.py
@@ -102,6 +102,7 @@ def optimize_loss(loss,
                   summaries=None,
                   larc_params=None,
                   loss_scaling=1.0,
+                  loss_scaling_params=None,
                   on_horovod=False,
                   iter_size=1,
                   skip_update_ph=None):
@@ -173,7 +174,10 @@ def optimize_loss(loss,
     opt = optimizer(learning_rate=lr, **optimizer_params)
 
     if isinstance(loss_scaling, six.string_types):
-      loss_scaling = AutomaticLossScaler(algorithm=loss_scaling)
+      loss_scaling = AutomaticLossScaler(
+          algorithm=loss_scaling,
+          params=loss_scaling_params
+      )
 
     if dtype == 'mixed':
       opt = MixedPrecisionOptimizerWrapper(opt, loss_scale=loss_scaling)

--- a/open_seq2seq/optimizers/optimizers.py
+++ b/open_seq2seq/optimizers/optimizers.py
@@ -50,6 +50,7 @@ OPTIMIZER_SUMMARIES = [
     "variables",
     "variable_norm",
     "larc_summaries",
+    "loss_scale"
 ]
 
 
@@ -139,7 +140,7 @@ def optimize_loss(loss,
     training op.
   """
   if summaries is None:
-    summaries = ["learning_rate", "global_gradient_norm"]
+    summaries = ["learning_rate", "global_gradient_norm", "loss_scale"]
   else:
     for summ in summaries:
       if summ not in OPTIMIZER_SUMMARIES:
@@ -178,6 +179,8 @@ def optimize_loss(loss,
           algorithm=loss_scaling,
           params=loss_scaling_params
       )
+      if "loss_scale" in summaries:
+        tf.summary.scalar("loss_scale", loss_scaling.loss_scale)
 
     if dtype == 'mixed':
       opt = MixedPrecisionOptimizerWrapper(opt, loss_scale=loss_scaling)
@@ -426,7 +429,7 @@ def _clip_by_global_norm(t_list, clip_norm, use_norm, name=None):
   #   use_norm = global_norm(t_list, name)
 
   with tf.name_scope(name, "clip_by_global_norm",
-                      t_list + [clip_norm]) as name:
+                     t_list + [clip_norm]) as name:
     # Calculate L2-norm, clip elements by ratio of clip_norm to L2-norm
     scale = clip_norm * tf.minimum(
         1.0 / use_norm,
@@ -458,3 +461,4 @@ def _clip_by_global_norm(t_list, clip_norm, use_norm, name=None):
         for (c_v, t) in zip(values_clipped, t_list)]
 
   return list_clipped, use_norm
+  


### PR DESCRIPTION
This pull request contains two changes that might be useful for development purposes.

The first change is the addition of a new tf.summary called "loss_scale" that logs AutomaticLossScaler.loss_scale. Note that this value may not be completely accurate. As steps are repeated if the current scale value results in errors and the current summary hook, to the best of my knowledge, only saves summaries every x steps, the logger might not capture the final scale after repeated steps, only the current scale at step x.
This change can be viewed in isolation at https://github.com/blisc/OpenSeq2Seq/tree/dev0.5-loss-scale-summary

The second change is the ability to change AutomaticLossScaler's algorithm's parameters from the config file via "loss_scaling_params". This way the parameters can be changed without having to edit automatic_loss_scaler.py.
This change can be viewed in isolation at https://github.com/blisc/OpenSeq2Seq/tree/dev0.5-loss-scaling-params