### PR TITLE
Add TRT mode for inference

### DIFF
--- a/open_seq2seq/models/model.py
+++ b/open_seq2seq/models/model.py
@@ -327,7 +327,7 @@ class Model:
     self._num_objects_per_step = None
     self.skip_update_ph = None
 
-  def compile(self, force_var_reuse=False):
+  def compile(self, force_var_reuse=False, checkpoint=None, use_trt=False, precision='FP32'):
     """TensorFlow graph is built here."""
     if 'initializer' not in self.params:
       initializer = None
@@ -354,9 +354,12 @@ class Model:
             self.get_data_layer(gpu_cnt).build_graph()
           input_tensors = self.get_data_layer(gpu_cnt).input_tensors
 
-          loss, self._outputs[gpu_cnt] = self._build_forward_pass_graph(
+          loss, self._outputs[gpu_cnt] = self.build_forward_pass_graph(
               input_tensors,
               gpu_id=gpu_cnt,
+              checkpoint=checkpoint,
+              use_trt=use_trt,
+              precision=precision
           )
           if self._outputs[gpu_cnt] is not None and \
              not isinstance(self._outputs[gpu_cnt], list):
@@ -461,6 +464,73 @@ class Model:
                      "number of parameters.")
         else:
           deco_print('Total trainable parameters: {}'.format(total_params))
+
+  def build_forward_pass_graph(self, input_tensors, gpu_id=0, checkpoint=None, use_trt=False, precision='FP32'):
+    """Wrapper around _build_forward_pass_graph with option of using TF-TRT"""
+    if use_trt:
+      import tensorflow.contrib.tensorrt as trt
+      # Create temporary graph which will contain the native TF graph
+      tf_config = tf.ConfigProto()
+      tf_config.gpu_options.allow_growth = True
+      temp_graph = tf.Graph()
+      with temp_graph.as_default() as tf_graph:
+        with tf.Session(config=tf_config) as tf_sess:
+          input_placeholders = {'source_tensors': [
+            tf.placeholder(shape=(None, None), dtype=tf.int32, name='input_map1'),
+            tf.placeholder(shape=(None, None), dtype=tf.int32, name='input_map2')
+            ]}
+          loss, self._outputs[gpu_id] = self._build_forward_pass_graph(
+              input_placeholders,
+              gpu_id=gpu_id
+          )
+          output_node_names = [x.name.split(':0')[0] for x in self._outputs[gpu_id]]
+          # Restore checkpoint here because we have to freeze the graph
+          tf_saver = tf.train.Saver()
+          tf_saver.restore(save_path=checkpoint, sess=tf_sess)
+          frozen_graph = tf.graph_util.convert_variables_to_constants(
+                tf_sess,
+                tf_sess.graph_def,
+                output_node_names=output_node_names
+          )
+          num_nodes = len(frozen_graph.node)
+          print('Converting graph using TensorFlow-TensorRT...')
+          frozen_graph = trt.create_inference_graph(
+            input_graph_def=frozen_graph,
+            outputs=output_node_names,
+            max_batch_size=64,
+            max_workspace_size_bytes=4096 << 20,
+            precision_mode=precision,
+            minimum_segment_size=3
+          )
+          print('Total node count before and after TF-TRT conversion:', num_nodes, '->', len(frozen_graph.node))
+          print('TRT node count:', len([1 for n in frozen_graph.node if str(n.op)=='TRTEngineOp']))
+      # Perform calibration for INT8 precision mode
+      if precision == 'int8':
+          with tf.Session(config=tf_config) as tf_sess:
+            calib_graph = frozen_graph
+            num_iterations = 10
+            print('Calibrating INT8...')
+            self._outputs[gpu_id] = tf.import_graph_def(calib_graph,
+                input_map={'input_map1': input_tensors['source_tensors'][0]},
+                return_elements=[x+':0' for x in output_node_names],
+                name='')
+            self._num_objects_per_step = [self._get_num_objects_per_step(worker_id)
+                                    for worker_id in range(self.num_gpus)]
+            results_per_batch = iterate_data(
+              self, tf_sess, compute_loss=False, mode='infer', verbose=False, num_steps=num_iterations
+            )
+            frozen_graph = trt.calib_graph_to_infer_graph(calib_graph)
+            del calib_graph
+            print('INT8 graph created.')
+            print('Nodes INT8:', len(frozen_graph.node))
+      # Import TRT converted graph to default graph, mapping it to the original input tensors
+      self._outputs[gpu_id] = tf.import_graph_def(frozen_graph,
+          input_map={'input_map1': input_tensors['source_tensors'][0]},
+          return_elements=[x+':0' for x in output_node_names],
+          name='')
+      return loss, self._outputs[gpu_id]
+    else:
+      return self._build_forward_pass_graph(input_tensors, gpu_id)
 
   @abc.abstractmethod
   def _build_forward_pass_graph(self, input_tensors, gpu_id=0):

--- a/open_seq2seq/utils/funcs.py
+++ b/open_seq2seq/utils/funcs.py
@@ -171,8 +171,10 @@ def train(train_model, eval_model=None, debug_port=None):
       deco_print("Not enough steps for benchmarking")
 
 
-def restore_and_get_results(model, checkpoint, mode):
-  saver = tf.train.Saver()
+def restore_and_get_results(model, checkpoint, mode, use_trt=False):
+   if not use_trt:
+    # Checkpoint is restored prior to freezing graph when using TRT
+    saver = tf.train.Saver()
   sess_config = tf.ConfigProto(allow_soft_placement=True)
   # pylint: disable=no-member
   sess_config.gpu_options.allow_growth = True
@@ -180,15 +182,16 @@ def restore_and_get_results(model, checkpoint, mode):
     # pylint: disable=no-member
     sess_config.gpu_options.visible_device_list = str(model.hvd.local_rank())
   with tf.Session(config=sess_config) as sess:
-    saver.restore(sess, checkpoint)
+    if not use_trt:
+      saver.restore(sess, checkpoint)
     results_per_batch = get_results_for_epoch(
         model, sess, mode=mode, compute_loss=False, verbose=True,
     )
   return results_per_batch
 
 
-def infer(model, checkpoint, output_file):
-  results_per_batch = restore_and_get_results(model, checkpoint, mode="infer")
+def infer(model, checkpoint, output_file, use_trt=False):
+  results_per_batch = restore_and_get_results(model, checkpoint, mode="infer", use_trt=use_trt)
   if not model.on_horovod or model.hvd.rank() == 0:
     model.finalize_inference(results_per_batch, output_file)
     deco_print("Finished inference")

--- a/open_seq2seq/utils/utils.py
+++ b/open_seq2seq/utils/utils.py
@@ -92,7 +92,7 @@ def clip_last_batch(last_batch, true_size):
   return last_batch_clipped
 
 
-def iterate_data(model, sess, compute_loss, mode, verbose):
+def iterate_data(model, sess, compute_loss, mode, verbose, num_steps=None):
   total_time = 0.0
   bench_start = model.params.get('bench_start', 10)
   results_per_batch = []
@@ -211,6 +211,9 @@ def iterate_data(model, sess, compute_loss, mode, verbose):
     if len(fetches_vals) == 0:
       break
     step += 1
+    # break early in the case of INT8 calibration
+    if num_steps is not None and step >= num_steps:
+      break
 
   if verbose:
     if step > bench_start:
@@ -501,6 +504,11 @@ def get_base_config(args):
                       help='run TensorFlow in debug mode on specified port')
   parser.add_argument('--enable_logs', dest='enable_logs', action='store_true',
                       help='whether to log output, git info, cmd args, etc.')
+  parser.add_argument('--use_trt', dest='use_trt', action='store_true',
+                      help='use TF-TRT to optimize graph for inference (mode must be infer)')
+  parser.add_argument('--precision', type=str, default='fp32',
+                      choices=['fp32', 'fp16', 'int8'],
+                      help='precision for TF-TRT (only valid with --use_trt')  
   args, unknown = parser.parse_known_args(args)
 
   if args.mode not in [
@@ -522,6 +530,9 @@ def get_base_config(args):
   base_model = config_module.get('base_model', None)
   if base_model is None:
     raise ValueError('base_config class has to be defined in the config file')
+
+  if args.use_trt and args.mode != 'infer':
+    raise ValueError("TensorRT is only supported for inference mode.")
 
   # after we read the config, trying to overwrite some of the properties
   # with command line arguments that were passed to the script
@@ -738,6 +749,7 @@ def create_model(args, base_config, config_module, base_model, hvd):
     model.compile(force_var_reuse=False)
   else:
     model = base_model(params=infer_config, mode=args.mode, hvd=hvd)
-    model.compile()
+    checkpoint = check_logdir(args, base_config)
+    model.compile(checkpoint=checkpoint, use_trt=args.use_trt, precision=args.precision)
 
   return model

--- a/run.py
+++ b/run.py
@@ -64,7 +64,7 @@ def main():
     elif args.mode == "eval":
       evaluate(model, checkpoint)
     elif args.mode == "infer":
-      infer(model, checkpoint, args.infer_output_file)
+      infer(model, checkpoint, args.infer_output_file, args.use_trt)
 
   if args.enable_logs and (hvd is None or hvd.rank() == 0):
     sys.stdout = old_stdout


### PR DESCRIPTION
This should allow improved inference performance. TRT can be toggled on using --use_trt flag.
FP32, FP16, and INT8 options are available and can be selected with --precision. Depending on
the version of TRT being used, there may not be much speedup because many operations are not
yet supported. INT8 mode will most likely not work at all - we can disable this argument if we want.