### PR TITLE
18.11 dev transformer embedding matrix gradient dense workaround

### DIFF
--- a/open_seq2seq/models/model.py
+++ b/open_seq2seq/models/model.py
@@ -464,6 +464,7 @@ class Model:
           on_horovod=self.on_horovod,
           iter_size=self.params.get('iter_size', 1),
           skip_update_ph=self.skip_update_ph,
+          model=self
       )
       tf.summary.scalar(name="train_loss", tensor=self.loss)
       if self.steps_in_epoch:


### PR DESCRIPTION
Addresses #244 

This is to fix an issue that can cause cause performance degradation and eventual OOM under these conditions:

Horovod distributed training
fp32 training
transformer model
iter_size set to 1

The issue does not seem to surface if iter_size > 1 because `tf.scatter_nd_add` takes care of densifying the gradient.  With mixed precision training enabled, it also doesn't happen though I've still to isolate the cause for this.

Specifically, Tensorflow tries to perform a sparse _and_ dense update for the embedding matrix.  Due to the nature of the Transformer model, the embedding matrix is used as the projection matrix before softmax layer (this is where dense gradient comes from) and for embedding lookups at the input layer (this is where the sparse gradient comes from).  For some reason, Tensorflow implements a dense and sparse update together as an IndexedSlices object.  In turn, Horovod uses allgather for IndexedSlices gradients.  So, roughly, the shape of the concatenated gradients across all GPUs after an allgather becomes:

**(num_gpus * (vocab size + num_src_tokens + num_target_tokens), hidden_size)** 
**(2 * (32768 + (128 * 56) + (128 * 56)), 512)**
**(94208, 512)**

The workaround is to deduplicate the indices within IndexedSlices by summing their values together and then converting it to a dense tensor.  This forces Horovod to avoid the allgather and instead use allreduce.  I've tried to be careful such that this code is only executed for the transformer model since the problem seems to be unique to it?  Review Horovod timeline  screenshots below to see the size of the resulting gradient for the embedding matrix.  With this dense workaround, the gradient shape will always be the shape of the embedding matrix, as it should be.  Please let me know if you have any issues reproducing the problem.

The problem worsens with more GPUs.  I've used 2 GPUs in the math above and the screenshots below.

Before the fix:
![screen shot 2018-10-11 at 3 52 45 pm](https://user-images.githubusercontent.com/2184688/46838381-e6ac9700-cd6d-11e8-9ef4-1aefced79f04.png)

After the fix:
![screen shot 2018-10-11 at 3 53 38 pm](https://user-images.githubusercontent.com/2184688/46838640-0ee8c580-cd6f-11e8-9479-2ccb25c1e288.png)
