### PR TITLE
Fix import_librivox.py path

### DIFF
--- a/docs/sources/source/speech-recognition/get_started_toy_model.rst
+++ b/docs/sources/source/speech-recognition/get_started_toy_model.rst
@@ -16,7 +16,7 @@ Assuming you are in the base folder, run::
 
     sudo apt-get -y install sox libsox-dev
     mkdir -p data
-    python import_librivox.py data/librispeech
+    python scripts/import_librivox.py data/librispeech
 
 Note, that this will take a lot of time, since
 it needs to download, extract and convert around 55GB of audio files. The final


### PR DESCRIPTION
get_started_toy_model.rst references the import_librivox.py - file in the root folder, but is in the scripts subfolder