### PR TITLE
remove redundant check_logdir

### DIFF
--- a/open_seq2seq/utils/utils.py
+++ b/open_seq2seq/utils/utils.py
@@ -698,7 +698,8 @@ def create_logdir(args, base_config):
 
   return old_stdout, old_stderr, stdout_log, stderr_log
 
-def create_model(args, base_config, config_module, base_model, hvd, restore_best_checkpoint=False):
+def create_model(args, base_config, config_module, base_model, hvd,
+                 checkpoint=None):
   """A helpful function that creates the train, eval, and infer models as
   needed.
 
@@ -709,6 +710,8 @@ def create_model(args, base_config, config_module, base_model, hvd, restore_best
     base_model (OpenSeq2Seq model): Dictionary as returned from
       get_base_config()
     hvd: Either None if Horovod is not enabled, or the Horovod library
+    checkpoint (str): checkpoint path as returned from
+      tf.train.latest_checkpoint
 
   Returns:
     model: A compiled model. For the 'train_eval' mode, a tuple containing the
@@ -784,9 +787,6 @@ def create_model(args, base_config, config_module, base_model, hvd, restore_best
     model.compile(force_var_reuse=False)
   else:
     model = base_model(params=infer_config, mode=args.mode, hvd=hvd)
-    if base_config['logdir'].endswith('logs'):
-      base_config['logdir'] =  base_config['logdir'][:-5]
-    checkpoint = check_logdir(args, base_config, restore_best_checkpoint)
     model.compile(checkpoint=checkpoint)
 
   return model

--- a/run.py
+++ b/run.py
@@ -71,8 +71,7 @@ def main():
   # Create model and train/eval/infer
   with tf.Graph().as_default():
     model = create_model(
-        args, base_config, config_module, base_model, hvd,
-        restore_best_checkpoint)
+        args, base_config, config_module, base_model, hvd, checkpoint)
     if args.mode == "train_eval":
       train(model[0], model[1], debug_port=args.debug_port)
     elif args.mode == "train":


### PR DESCRIPTION
We call check_logdir in run.py on line 35, and then again if we are running infer then we call check_logdir again inside create_model inside utils.py on line 764.
To further complicate matters, we sometimes check two different logdirs.
The second check_logdir has been removed and we simply pass the checkpoint recovered from the first check_logdir call to create_model as a parameter as opposed to fetching it again.

Rebase from #279 