### PR TITLE
py2 compatibility fix for lmutils

### DIFF
--- a/open_seq2seq/data/lm/lmutils.py
+++ b/open_seq2seq/data/lm/lmutils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from collections import Counter
 import glob
 import os


### PR DESCRIPTION
This is the only fix needed to make OpenSeq2Seq work with py2 TensorFlow container pulled from NGC.