### PR TITLE
Relax comparison check in CrossEntropyWithSmoothingEqualsBasicSequenc…

### DIFF
--- a/open_seq2seq/losses/sequence_loss_test.py
+++ b/open_seq2seq/losses/sequence_loss_test.py
@@ -57,7 +57,7 @@ class CrossEntropyWithSmoothingEqualsBasicSequenceLossTest(tf.test.TestCase):
               }
               loss1 = sess.run(l1, feed_dict=feed_dict)
               loss2 = sess.run(l2, feed_dict=feed_dict)
-              self.assertEqual(loss1, loss2)
+              self.assertAlmostEqual(loss1, loss2, 4)
               print("Loss: {}".format(loss1))
 
 


### PR DESCRIPTION
…eLossTest

The check is too strong when run with: TF_XLA_FLAGS=--tf_xla_auto_jit=1.
Compiling with xla changes the computation, resulting in failure with the following message:

Traceback (most recent call last):
  File "/opt/tensorflow/nvidia-examples/OpenSeq2Seq/open_seq2seq/losses/sequence_loss_test.py", line 60, in test_compute_loss
    self.assertEqual(loss1, loss2)
AssertionError: 32.645237 != 32.64524

Only comparing the first 4 decimals makes the test succeed again