### PR TITLE
Script for downloading and pre-processing wikitext datasets

### DIFF
--- a/scripts/obtain_datasets_lm.sh
+++ b/scripts/obtain_datasets_lm.sh
@@ -1,0 +1,25 @@
+echo "=== Downloading datasets ==="
+echo "---"
+
+mkdir -p data
+cd data
+
+echo "- Downloading WikiText-2 (WT2)"
+wget --continue https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-2-v1.zip
+unzip -q wikitext-2-v1.zip
+cd wikitext-2
+mv wiki.train.tokens train.txt
+mv wiki.valid.tokens valid.txt
+mv wiki.test.tokens test.txt
+cd ..
+
+echo "- Downloading WikiText-103 (WT2)"
+wget --continue https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-103-v1.zip
+unzip -q wikitext-103-v1.zip
+cd wikitext-103
+mv wiki.train.tokens train.txt
+mv wiki.valid.tokens valid.txt
+mv wiki.test.tokens test.txt
+cd ..
+
+echo "=== Download and pre-processing completed ==="

--- a/scripts/obtain_datasets_lm.sh
+++ b/scripts/obtain_datasets_lm.sh
@@ -13,7 +13,7 @@ mv wiki.valid.tokens valid.txt
 mv wiki.test.tokens test.txt
 cd ..
 
-echo "- Downloading WikiText-103 (WT2)"
+echo "- Downloading WikiText-103 (WT103)"
 wget --continue https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-103-v1.zip
 unzip -q wikitext-103-v1.zip
 cd wikitext-103


### PR DESCRIPTION
Added an automated script for downloading and pre-processing wikitext-103 and wikitext-2 datasets for the LSTM language models, in the format described in https://nvidia.github.io/OpenSeq2Seq/html/language-model.html. This is very helpful for generating the files needed for training LSTM language models.